### PR TITLE
make builds work and tests pass.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 bower_components/
+/config/ember-try.js
 tests/
 
 .bowerrc

--- a/.npmignore
+++ b/.npmignore
@@ -8,5 +8,5 @@ tests/
 .npmignore
 **/.gitkeep
 bower.json
-Brocfile.js
+ember-cli-build.js
 testem.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,34 @@ sudo: false
 
 cache:
   directories:
-    - node_modules
+    - $HOME/.npm
+    - $HOME/.cache # includes bowers cache
+
+env:
+  # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
+  - EMBER_TRY_SCENARIO=ember-lts-2.8
+  - EMBER_TRY_SCENARIO=ember-release
+  - EMBER_TRY_SCENARIO=ember-beta
+  - EMBER_TRY_SCENARIO=ember-canary
+  - EMBER_TRY_SCENARIO=ember-default
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - "npm config set spin false"
+  - npm config set spin false
+  - npm install -g bower phantomjs-prebuilt
+  - bower --version
+  - phantomjs --version
 
 install:
-  - npm install -g bower
   - npm install
   - bower install
 
 script:
-  - npm test
+  # Usually, it's ok to finish the test scenario without reverting
+  #  to the addon's original dependency state, skipping "cleanup".
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 ---
 language: node_js
+node_js:
+  - "4"
 
 sudo: false
 
@@ -9,7 +11,6 @@ cache:
 
 before_install:
   - "npm config set spin false"
-  - "npm install -g npm@^2"
 
 install:
   - npm install -g bower

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # ember-datepicker Changelog
 
+### 3.0.0
+
 ### 2.0.1 (February 10, 2015)
  * [FEATURE #28] Clear text input when date is reset
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,0 @@
-The MIT License (MIT)
-
-Copyright (c) 2015
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/bower.json
+++ b/bower.json
@@ -1,18 +1,5 @@
 {
   "name": "ember-cli-datepicker",
-  "dependencies": {
-    "jquery": "^1.11.1",
-    "ember": "1.10.0",
-    "ember-resolver": "~0.1.11",
-    "loader.js": "ember-cli/loader.js#1.0.1",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.0",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-data": "1.0.0-beta.14",
-    "ember-qunit": "0.1.8",
-    "ember-qunit-notifications": "0.0.5",
-    "qunit": "~1.17.1"
-  },
   "devDependencies": {
     "pikaday": "~1.2.0",
     "moment": "~2.8.3"

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,0 +1,91 @@
+/* global module */
+module.exports = {
+  scenarios: [
+    {
+      name: 'ember-lts-2.4',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#lts-2-4'
+        },
+        resolutions: {
+          'ember': 'lts-2-4'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-lts-2.8',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#lts-2-8'
+        },
+        resolutions: {
+          'ember': 'lts-2-8'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-release',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#release'
+        },
+        resolutions: {
+          'ember': 'release'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-beta',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#beta'
+        },
+        resolutions: {
+          'ember': 'beta'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-canary',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#canary'
+        },
+        resolutions: {
+          'ember': 'canary'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-default',
+      npm: {
+        devDependencies: {}
+      }
+    }
+  ]
+};

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,6 +3,7 @@
 
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
+module.exports = function(defaults) {
 var app = new EmberAddon({
   vendorFiles: {
     'handlebars.js': null
@@ -26,4 +27,5 @@ app.import(app.bowerDirectory + '/moment/moment.js');
 app.import(app.bowerDirectory + '/pikaday/pikaday.js');
 app.import(app.bowerDirectory + '/pikaday/css/pikaday.css');
 
-module.exports = app.toTree();
+return app.toTree();
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "ember server",
     "build": "ember build",
-    "test": "ember test"
+    "test": "ember try:each"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-datepicker",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "An Ember datepicker component using Pikaday and momentjs",
   "directories": {
     "doc": "doc",
@@ -16,7 +16,7 @@
     "url": "https://github.com/squirelabs/ember-datepicker"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4"
   },
   "keywords": [
     "ember-addon"
@@ -32,21 +32,26 @@
     "url": "https://github.com/squirelabs/ember-datepicker/issues"
   },
   "homepage": "https://github.com/squirelabs/ember-datepicker",
+  "dependencies": {
+    "ember-cli-babel": "^5.1.7"
+  },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
-    "ember-cli": "0.1.12",
-    "ember-cli-6to5": "^3.0.0",
+    "ember-cli": "2.12.0",
     "ember-cli-content-security-policy": "0.3.0",
-    "ember-cli-dependency-checker": "0.0.7",
-    "ember-cli-htmlbars": "^0.6.0",
-    "ember-cli-ic-ajax": "0.1.1",
-    "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.1",
+    "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-htmlbars": "^1.1.1",
+    "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-qunit": "^3.1.0",
+    "ember-cli-shims": "^1.0.2",
     "ember-cli-app-version": "0.3.1",
     "ember-cli-uglify": "1.0.1",
-    "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",
+    "ember-load-initializers": "^0.6.0",
+    "ember-resolver": "^2.0.3",
+    "ember-source": "~2.12.0",
     "express": "^4.8.5",
-    "glob": "^4.0.5"
+    "glob": "^4.0.5",
+    "loader.js": "^4.2.3"
   }
 }

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import Resolver from 'ember/resolver';
-import loadInitializers from 'ember/load-initializers';
+import Resolver from 'ember-resolver';
+import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
 Ember.MODEL_FACTORY_INJECTIONS = true;

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,16 +9,16 @@
 
     {{content-for 'head'}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for 'head-footer'}}
   </head>
   <body>
     {{content-for 'body'}}
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
 
     {{content-for 'body-footer'}}
   </body>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import config from './config/environment';
 
 var Router = Ember.Router.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 });
 
 Router.map(function() {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -4,7 +4,7 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'dummy',
     environment: environment,
-    baseURL: '/',
+    rootURL: '/',
     locationType: 'auto',
     EmberENV: {
       FEATURES: {
@@ -29,7 +29,6 @@ module.exports = function(environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.baseURL = '/';
     ENV.locationType = 'none';
 
     // keep test console output quieter
@@ -40,7 +39,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-    ENV.baseURL = '/ember-datepicker'
+    ENV.rootURL = '/ember-datepicker'
   }
 
   return ENV;

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,4 +1,4 @@
-import Resolver from 'ember/resolver';
+import Resolver from 'ember-resolver';
 import config from '../../config/environment';
 
 var resolver = Resolver.create();

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,9 +10,9 @@
     {{content-for 'head'}}
     {{content-for 'test-head'}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
-    <link rel="stylesheet" href="assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for 'head-footer'}}
     {{content-for 'test-head-footer'}}
@@ -21,11 +21,11 @@
 
     {{content-for 'body'}}
     {{content-for 'test-body'}}
-    <script src="assets/vendor.js"></script>
-    <script src="assets/test-support.js"></script>
-    <script src="assets/dummy.js"></script>
-    <script src="testem.js"></script>
-    <script src="assets/tests.js"></script>
+    <script src="/testem.js" integrity=""></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for 'body-footer'}}
     {{content-for 'test-body-footer'}}

--- a/tests/index.html
+++ b/tests/index.html
@@ -25,7 +25,7 @@
     <script src="assets/test-support.js"></script>
     <script src="assets/dummy.js"></script>
     <script src="testem.js"></script>
-    <script src="assets/test-loader.js"></script>
+    <script src="assets/tests.js"></script>
 
     {{content-for 'body-footer'}}
     {{content-for 'test-body-footer'}}

--- a/tests/integration/misc-test.js
+++ b/tests/integration/misc-test.js
@@ -6,6 +6,7 @@ import { test, moduleForComponent } from 'ember-qunit';
 var App, component;
 
 moduleForComponent('date-picker', 'ember-cli-datepicker integration', {
+  unit: true,
   setup: function() {
     App = startApp();
   },

--- a/tests/integration/misc-test.js
+++ b/tests/integration/misc-test.js
@@ -19,21 +19,21 @@ moduleForComponent('date-picker', 'ember-cli-datepicker integration', {
   }
 });
 
-test("it shows the picker on input focus, then hides it after click outside", function() {
-  expect(3);
+test("it shows the picker on input focus, then hides it after click outside", function(assert) {
+  assert.expect(3);
   component = this.subject();
 
   // initial render
   this.$();
 
-  equal($('.pika-single').hasClass('is-hidden'), true, "date picker is initially hidden");
+  assert.equal($('.pika-single').hasClass('is-hidden'), true, "date picker is initially hidden");
 
   click(this.$());
   andThen(function() {
-    equal($('.pika-single').hasClass('is-hidden'), false, "date picker is visible");
+    assert.equal($('.pika-single').hasClass('is-hidden'), false, "date picker is visible");
     click(document.body);
   });
   andThen(function() {
-    equal($('.pika-single').hasClass('is-hidden'), true, "date picker is hidden again");
+    assert.equal($('.pika-single').hasClass('is-hidden'), true, "date picker is hidden again");
   });
 });

--- a/tests/unit/date-picker-component-test.js
+++ b/tests/unit/date-picker-component-test.js
@@ -6,6 +6,7 @@ import { test, moduleForComponent } from 'ember-qunit';
 var App, component;
 
 moduleForComponent('date-picker', 'ember-cli-datepicker component', {
+  unit: true,
   setup: function() {
     App = startApp();
   },

--- a/tests/unit/date-picker-component-test.js
+++ b/tests/unit/date-picker-component-test.js
@@ -231,7 +231,7 @@ test("it creates UTC timestamp when `utc: true`", function(assert) {
 
     // without utc = true, expect timestamp that differs from UTC unix timestamp
     // by the current timezoneOffset in seconds
-    assert.equal(component.get('date'), unixTimestamp2000 + (new Date()).getTimezoneOffset()*60,
+    assert.equal(component.get('date'), unixTimestamp2000 + (new Date('2000-01-01')).getTimezoneOffset()*60,
       "outputs timestamp that differs by timezoneOffset when utc = false");
 
     component.set('utc', true);

--- a/tests/unit/date-picker-component-test.js
+++ b/tests/unit/date-picker-component-test.js
@@ -23,31 +23,31 @@ moduleForComponent('date-picker', 'ember-cli-datepicker component', {
  * Test initially displayed date with default and custon `format` and also
  * with the `allowBlank` option
  */
-test("it displays today's date with default format when no date is set", function() {
-  expect(1);
+test("it displays today's date with default format when no date is set", function(assert) {
+  assert.expect(1);
   component = this.subject();
   var formattedDate = moment().format(component.get('format'));
 
-  equal(this.$().val(), formattedDate, "displays date");
+  assert.equal(this.$().val(), formattedDate, "displays date");
 });
 
-test("it displays today's date with custom `format` when no date is set", function() {
-  expect(1);
+test("it displays today's date with custom `format` when no date is set", function(assert) {
+  assert.expect(1);
   component = this.subject({
     format: 'DD.MM.YY'
   });
   var formattedDate = moment().format('DD.MM.YY');
 
-  equal(this.$().val(), formattedDate, "displays date with custom format");
+  assert.equal(this.$().val(), formattedDate, "displays date with custom format");
 });
 
-test("it displays nothing when no date is set and `allowBlank: true`", function() {
-  expect(1);
+test("it displays nothing when no date is set and `allowBlank: true`", function(assert) {
+  assert.expect(1);
   component = this.subject({
     allowBlank: true
   });
 
-  equal(this.$().val(), "", "input is empty");
+  assert.equal(this.$().val(), "", "input is empty");
 });
 
 
@@ -55,62 +55,62 @@ test("it displays nothing when no date is set and `allowBlank: true`", function(
  * Test whether opening and closing the date picker affects the bound date value
  * with and without `allowBlank`
  */
-test("it sets bound date after open + close", function() {
-  expect(2);
+test("it sets bound date after open + close", function(assert) {
+  assert.expect(2);
   component = this.subject({
     allowBlank: false
   });
 
   this.$();
   var todaysDate = moment().format(component.get('valueFormat'));
-  equal(component.get('date'), todaysDate, "has initial date of today");
+  assert.equal(component.get('date'), todaysDate, "has initial date of today");
 
   // simulate open + close of picker
   component.get('_picker').show();
   component.get('_picker').hide();
 
-  ok(component.get('date'), "has a date");
+  assert.ok(component.get('date'), "has a date");
 });
 
-test("it does not set bound date after open + close when `allowBlank: true`", function() {
-  expect(2);
+test("it does not set bound date after open + close when `allowBlank: true`", function(assert) {
+  assert.expect(2);
   component = this.subject({
     allowBlank: true
   });
 
   // initial render
   this.$();
-  equal(component.get('date'), null, "has no initial date");
+  assert.equal(component.get('date'), null, "has no initial date");
 
   // simulate open + close of picker
   component.get('_picker').show();
   component.get('_picker').hide();
 
-  equal(component.get('date'), null, "still has no date");
+  assert.equal(component.get('date'), null, "still has no date");
 });
 
 
 /**
  * Misc
  */
-test("it shows date picker after click on input field", function() {
-  expect(2);
+test("it shows date picker after click on input field", function(assert) {
+  assert.expect(2);
   component = this.subject();
 
   // initial render
   this.$();
 
-  equal($('.pika-single').hasClass('is-hidden'), true, "date picker is initially hidden");
+  assert.equal($('.pika-single').hasClass('is-hidden'), true, "date picker is initially hidden");
 
   click(this.$());
 
   andThen(function() {
-    equal($('.pika-single').hasClass('is-hidden'), false, "date picker is shown");
+    assert.equal($('.pika-single').hasClass('is-hidden'), false, "date picker is shown");
   });
 });
 
-test("it updates displayed value when bound date changes", function() {
-  expect(1);
+test("it updates displayed value when bound date changes", function(assert) {
+  assert.expect(1);
   component = this.subject();
 
   // initial render
@@ -118,11 +118,11 @@ test("it updates displayed value when bound date changes", function() {
 
   component.set('date', moment("2000-01-01").format('X'));
 
-  equal(this.$().val(), "2000-01-01", "displays new date");
+  assert.equal(this.$().val(), "2000-01-01", "displays new date");
 });
 
-test("it updates displayed value to nothing when date is unset after having a previous value and `allowBlank: true`", function() {
-  expect(2);
+test("it updates displayed value to nothing when date is unset after having a previous value and `allowBlank: true`", function(assert) {
+  assert.expect(2);
   component = this.subject({
     allowBlank: true
   });
@@ -132,11 +132,11 @@ test("it updates displayed value to nothing when date is unset after having a pr
 
   component.set('date', moment("2000-01-01").format('X'));
 
-  equal(this.$().val(), "2000-01-01", "displays new date");
+  assert.equal(this.$().val(), "2000-01-01", "displays new date");
 
   component.set('date', null);
 
-  equal(this.$().val(), "", "input is empty");
+  assert.equal(this.$().val(), "", "input is empty");
 });
 
 /**
@@ -144,8 +144,8 @@ test("it updates displayed value to nothing when date is unset after having a pr
  * custom string format and "date" format which causes the output of a real
  * JS Date object
  */
-test("it respects `format` when parsing date value", function() {
-  expect(1);
+test("it respects `format` when parsing date value", function(assert) {
+  assert.expect(1);
   component = this.subject({
     format: 'dddd, MMMM Do YYYY'
   });
@@ -157,12 +157,12 @@ test("it respects `format` when parsing date value", function() {
     // simulate open + close of picker
     component.get('_picker').show();
     component.get('_picker').hide();
-    equal(component.get('date'), moment("2000-01-01").format('X'), "sets correct date");
+    assert.equal(component.get('date'), moment("2000-01-01").format('X'), "sets correct date");
   });
 });
 
-test("it respects `valueFormat: 'date'` when setting date value", function() {
-  expect(1);
+test("it respects `valueFormat: 'date'` when setting date value", function(assert) {
+  assert.expect(1);
   component = this.subject({
     valueFormat: 'date'
   });
@@ -174,12 +174,12 @@ test("it respects `valueFormat: 'date'` when setting date value", function() {
     component.get('_picker').show();
     component.get('_picker').hide();
 
-    equal(component.get('date').toString(), moment("2000-01-01").toDate().toString(), "sets correct date");
+    assert.equal(component.get('date').toString(), moment("2000-01-01").toDate().toString(), "sets correct date");
   });
 });
 
-test("it respects `valueFormat: 'moment'` when setting date value", function() {
-  expect(1);
+test("it respects `valueFormat: 'moment'` when setting date value", function(assert) {
+  assert.expect(1);
   component = this.subject({
     valueFormat: 'moment'
   });
@@ -191,12 +191,12 @@ test("it respects `valueFormat: 'moment'` when setting date value", function() {
     component.get('_picker').show();
     component.get('_picker').hide();
 
-    equal(component.get('date').format(), moment("2000-01-01").format(), "sets correct moment object");
+    assert.equal(component.get('date').format(), moment("2000-01-01").format(), "sets correct moment object");
   });
 });
 
-test("it respects `valueFormat` when setting date value", function() {
-  expect(1);
+test("it respects `valueFormat` when setting date value", function(assert) {
+  assert.expect(1);
   component = this.subject({
     valueFormat: 'dddd, MMMM Do YYYY'
   });
@@ -208,15 +208,15 @@ test("it respects `valueFormat` when setting date value", function() {
     component.get('_picker').show();
     component.get('_picker').hide();
 
-    equal(component.get('date'), moment("2000-01-01").format('dddd, MMMM Do YYYY'), "sets currect date");
+    assert.equal(component.get('date'), moment("2000-01-01").format('dddd, MMMM Do YYYY'), "sets currect date");
   });
 });
 
 /**
  * Test `utc` option that creates date objects in UTC mode.
  */
-test("it creates UTC timestamp when `utc: true`", function() {
-  expect(2);
+test("it creates UTC timestamp when `utc: true`", function(assert) {
+  assert.expect(2);
   component = this.subject();
 
   fillIn(this.$(), "2000-01-01");
@@ -231,7 +231,7 @@ test("it creates UTC timestamp when `utc: true`", function() {
 
     // without utc = true, expect timestamp that differs from UTC unix timestamp
     // by the current timezoneOffset in seconds
-    equal(component.get('date'), unixTimestamp2000 + (new Date()).getTimezoneOffset()*60,
+    assert.equal(component.get('date'), unixTimestamp2000 + (new Date()).getTimezoneOffset()*60,
       "outputs timestamp that differs by timezoneOffset when utc = false");
 
     component.set('utc', true);
@@ -240,13 +240,13 @@ test("it creates UTC timestamp when `utc: true`", function() {
     component.get('_picker').show();
     component.get('_picker').hide();
 
-    equal(component.get('date'), unixTimestamp2000,
+    assert.equal(component.get('date'), unixTimestamp2000,
       "outputs exact timestamp of date when utc = true");
   });
 });
 
-test("it creates UTC date object when `utc: true`", function() {
-  expect(2);
+test("it creates UTC date object when `utc: true`", function(assert) {
+  assert.expect(2);
   component = this.subject({
     valueFormat: 'date'
   });
@@ -258,7 +258,7 @@ test("it creates UTC date object when `utc: true`", function() {
     component.get('_picker').show();
     component.get('_picker').hide();
 
-    equal(component.get('date').toISOString(), moment("2000-01-01").toDate().toISOString(),
+    assert.equal(component.get('date').toISOString(), moment("2000-01-01").toDate().toISOString(),
       "outputs regular date that equals locally generated date when utc = false");
 
     component.set('utc', true);
@@ -267,7 +267,7 @@ test("it creates UTC date object when `utc: true`", function() {
     component.get('_picker').show();
     component.get('_picker').hide();
 
-    equal(component.get('date').toISOString(), "2000-01-01T00:00:00.000Z",
+    assert.equal(component.get('date').toISOString(), "2000-01-01T00:00:00.000Z",
       "outputs regular date that equals utc date when utc = true");
   });
 });
@@ -275,8 +275,8 @@ test("it creates UTC date object when `utc: true`", function() {
 /**
  * Test `yearRange` for both string and array
  */
-test("it sets correct year range for relative string", function() {
-  expect(2);
+test("it sets correct year range for relative string", function(assert) {
+  assert.expect(2);
   component = this.subject({
     yearRange: '-2, 3'
   });
@@ -284,22 +284,22 @@ test("it sets correct year range for relative string", function() {
   var cy = window.moment().year(),
       expectedResult = [cy-2, cy+3];
 
-  equal(component.get('_yearRange')[0], expectedResult[0], "start date");
-  equal(component.get('_yearRange')[1], expectedResult[1], "end date");
+  assert.equal(component.get('_yearRange')[0], expectedResult[0], "start date");
+  assert.equal(component.get('_yearRange')[1], expectedResult[1], "end date");
 });
 
-test("it sets correct year range for absolute string", function() {
-  expect(2);
+test("it sets correct year range for absolute string", function(assert) {
+  assert.expect(2);
   component = this.subject({
     yearRange: '2000, 2020'
   });
 
-  equal(component.get('_yearRange')[0], 2000, "start date");
-  equal(component.get('_yearRange')[1], 2020, "end date");
+  assert.equal(component.get('_yearRange')[0], 2000, "start date");
+  assert.equal(component.get('_yearRange')[1], 2020, "end date");
 });
 
-test("it sets correct year range for relative array", function() {
-  expect(2);
+test("it sets correct year range for relative array", function(assert) {
+  assert.expect(2);
   component = this.subject({
     yearRange: ['-2', 3]
   });
@@ -307,16 +307,16 @@ test("it sets correct year range for relative array", function() {
   var cy = window.moment().year(),
       expectedResult = [cy-2, cy+3];
 
-  equal(component.get('_yearRange')[0], expectedResult[0], "start date");
-  equal(component.get('_yearRange')[1], expectedResult[1], "end date");
+  assert.equal(component.get('_yearRange')[0], expectedResult[0], "start date");
+  assert.equal(component.get('_yearRange')[1], expectedResult[1], "end date");
 });
 
-test("it sets correct year range for absolute array", function() {
-  expect(2);
+test("it sets correct year range for absolute array", function(assert) {
+  assert.expect(2);
   component = this.subject({
     yearRange: [2000, '2020']
   });
 
-  equal(component.get('_yearRange')[0], 2000, "start date");
-  equal(component.get('_yearRange')[1], 2020, "end date");
+  assert.equal(component.get('_yearRange')[0], 2000, "start date");
+  assert.equal(component.get('_yearRange')[1], 2020, "end date");
 });


### PR DESCRIPTION
* updates ember and ember-cli dependencies.
* updates tests to use injected assert object.
* uses new names for imports.
* switch from deprecated Brocfile.js to ember-cli-build.js.
* switch from deprecated baseURL property in environment to rootURL.
* fixed a broken test that only worked outside DST or UTC.
* bump version.
* update travis-ci config.
  * tests against 6 named versions of ember

You can see the automated build output at https://travis-ci.org/bangpound/ember-datepicker/builds/212685598. Demo at https://bangpound.org/ember-datepicker/.

This still needs to be tested within our app, so don't merge it.