### PR TITLE
[#CONTACTS-1040] add theme to list of options

### DIFF
--- a/addon/components/date-picker.js
+++ b/addon/components/date-picker.js
@@ -76,7 +76,7 @@ export default Em.TextField.extend({
 
     ['bound', 'position', 'reposition', 'format', 'firstDay', 'minDate',
      'maxDate', 'showWeekNumber', 'isRTL', 'i18n', 'yearSuffix', 'disableWeekends', 'disableDayFn',
-     'showMonthAfterYear', 'numberOfMonths', 'mainCalendar'].forEach(function(f) {
+     'showMonthAfterYear', 'numberOfMonths', 'mainCalendar', 'theme'].forEach(function(f) {
        if (!Em.isEmpty(that.get(f))) {
          pickerOptions[f] = that.get(f);
        }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-datepicker",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "An Ember datepicker component using Pikaday and momentjs",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
This PR adds "theme" to the list of allowed datepicker options. This will allow us to add additional classes to the datepicker. 

https://at.activecampaign.com/browse/CONTACTS-1040